### PR TITLE
fix BigNat.lesser() for operands of different size

### DIFF
--- a/applet/src/main/java/opencrypto/jcmathlib/BigNat.java
+++ b/applet/src/main/java/opencrypto/jcmathlib/BigNat.java
@@ -587,6 +587,16 @@ public class BigNat {
         short j;
 
         j = (short) (other.size + shift - this.size + start);
+
+        // TODO: what's the expected behavior when start > 0?
+        if (start == 0) {
+            for (short i = 0; i < j; ++i) {
+                if (other.value[i] != 0) {
+                    return true;
+                }
+            }
+        }
+
         short thisShort, otherShort;
         for (short i = start; i < this.size; i++, j++) {
             thisShort = (short) (this.value[i] & DIGIT_MASK);


### PR DESCRIPTION
The BigNat class in OV-Chip 2.0 [0] on which JCMathLib's BigNat is based on contained the following assertions:

```java
    #ifndef NO_CARD_ASSERT
        j = (short)(other.size + shift - this.size);
        // If j is positive there are j digits of other hanging on
        // the left of the first digit of this.
        for(short i = 0; i < j; i++) {
            ASSERT_TAG(other.value[i] == 0, 0x25);
        }
        // If j is negative, then this is longer than other and
        // -j digits are missing at the start of other.
        for(short i = 0; i < start; i++, j++) {
            ASSERT_TAG(this.value[i] == 0, 0x26);
            if(j >= 0) {
                ASSERT_TAG(other.value[j] == 0, 0x27);
            }
        }
    #endif
```

With the assertions removed, JCMathLib ignores any non-zero leading digits in other if other.size > this.size.

[0] https://www.sos.cs.ru.nl/ovchip/