### PR TITLE
minor fix: update curve params after reset in ECExample

### DIFF
--- a/applet/src/main/java/opencrypto/jcmathlib/ECExample.java
+++ b/applet/src/main/java/opencrypto/jcmathlib/ECExample.java
@@ -44,6 +44,7 @@ public class ECExample extends Applet {
     public boolean select() {
         if (initialized) {
             rm.refreshAfterReset();
+            curve.updateAfterReset();
         }
         return true;
     }


### PR DESCRIPTION
This is necessary for proper functioning following this commit: https://github.com/dufkan/JCMathLib/commit/068de82